### PR TITLE
Fix flashing of zips inside directories with spaces in their names

### DIFF
--- a/META-INF/com/google/android/update-binary
+++ b/META-INF/com/google/android/update-binary
@@ -29,7 +29,7 @@ show_progress 1.34 4;
 ui_print " ";
 mkdir -p /tmp/anykernel;
 cd /tmp/anykernel;
-unzip -o $ZIP;
+unzip -o "$ZIP";
 
 ui_print "$(file_getprop /tmp/anykernel/anykernel.sh kernel.string)";
 ui_print " ";


### PR DESCRIPTION
It seems like the " in Line 6 are not enough, unzip still refused to unpack files inside a directory with a space in it's name.
The new " fix that and now allow us to flash zips inside folders with spaces in their names.

Tested with M5 Kernel on the Sony Xperia Z3 as in here: https://github.com/Myself5/M5KernelTools/commit/16304f5f024afd1fa5eeb1875eeb4226362f1286
(I know the commit history is a bit messy, I'm going to fix that as soon as I find some time to give proper credits ofc)
