### PR TITLE
Add Support to ZImage-dtb (dtb its already appended)

### DIFF
--- a/anykernel.sh
+++ b/anykernel.sh
@@ -73,6 +73,8 @@ write_boot() {
   fi;
   if [ -f /tmp/anykernel/zImage ]; then
     kernel=/tmp/anykernel/zImage;
+  elif [ -f /tmp/anykernel/zImage-dtb ]; then
+    kernel=/tmp/anykernel/zImage-dtb;
   else
     kernel=`ls *-zImage`;
     kernel=$split_img/$kernel;


### PR DESCRIPTION
Some kernels build the ZImage with the dtb already appended, the result is a ZImage-dtb
