### PR TITLE
Backend: Only apply contexts to new modules

### DIFF
--- a/META-INF/com/google/android/update-binary
+++ b/META-INF/com/google/android/update-binary
@@ -93,14 +93,18 @@ if [ "$(file_getprop /tmp/anykernel/anykernel.sh do.modules)" == 1 ]; then
   mount -o rw,remount -t auto /vendor 2>/dev/null;
   cd /tmp/anykernel/modules;
   for module in $(find . -name '*.ko'); do
+    if [ ! -e /$module ]; then
+      case $module in
+        */vendor/*) mod=vendor;;
+        *) mod=system;;
+      esac;
+    fi;
     $bb cp -rLf $module /$module;
     $bb chown 0:0 /$module;
     $bb chmod 644 /$module;
-    case $module in
-      */vendor/*) mod=vendor;;
-      *) mod=system;;
-    esac;
-    chcon "u:object_r:${mod}_file:s0" /$module;
+    if [ "$mod" ]; then
+      chcon "u:object_r:${mod}_file:s0" /$module;
+    fi;
   done;
   cd /tmp/anykernel;
   mount -o ro,remount -t auto /system;


### PR DESCRIPTION
After working on the OnePlus 5/T with custom ROMs on Android 8.1.0, I
have noticed that several of them have modules in /system/lib/modules
with a context of "u:object_r:vendor_file:s0", which goes against the
assumption made in commit 6b11373 ("update-binary: Change how we handle
modules"). Because the context is changed, there is an SELinux denial
when trying to load the module during init.

While it would be nice for ROMs to fix that on their own, I suspect
they are not entirely at fault. Google's documentation does state that
all modules should be loaded from vendor whenever possible so I would
guess Google decided to force *.ko objects to have a vendor_file
context. This is all speculation as I haven't cared to do research into
the subject.

Easiest way around this is to just worry about applying contexts to new
modules. cp does not override contexts so if the module was already
present, we can assume it has the correct context to begin with.