### PR TITLE
AK2: Fix insert_line line validation

### DIFF
--- a/tools/ak2-core.sh
+++ b/tools/ak2-core.sh
@@ -384,7 +384,7 @@ insert_line() {
       after) offset=1;;
     esac;
     line=$((`grep -n "$4" $1 | head -n1 | cut -d: -f1` + offset));
-    if [ "$(wc -l $1 | cut -d\  -f1)" -le "$line" ]; then
+    if [ "$(wc -l $1 | cut -d\  -f1)" -lt "$line" ]; then
       echo "$5" >> $1;
     else
       sed -i "${line}s;^;${5}\n;" $1;


### PR DESCRIPTION
Currently, trying to use insert_line to insert something on the second
to last line fails and places it on the last line.

AK2 line:

insert_line test "sched_boost 0" after "on property:sys.boot_completed=1" "    write /proc/sys/kernel/sched_boost 0"

Before:

on property:sys.boot_completed=1
    bootchart stop

After:

on property:sys.boot_completed=1
    bootchart stop
    write /proc/sys/kernel/sched_boost 0

Expected result:

on property:sys.boot_completed=1
    write /proc/sys/kernel/sched_boost 0
    bootchart stop

In this example, the file length is 2 but the line we're inserting
at is also 2, which is perfectly fine because everything will get
shifted down by 1. Only if the file length is less than the desired
position (in this example, 3) should be handled by >>. All three
cases are now handled fine by insert_line (position 1, 2, and 3).

Signed-off-by: Nathan Chancellor <natechancellor@gmail.com>