### PR TITLE
ak2-core.sh: fix repacking of Sony ELF kernels

### DIFF
--- a/tools/ak2-core.sh
+++ b/tools/ak2-core.sh
@@ -214,8 +214,8 @@ flash_boot() {
   done;
   if [ ! "$dtb" -a -f *-dtb ]; then
     dtb=`ls *-dtb`;
-    dtb="--dt $split_img/$dtb";
     rpm="$split_img/$dtb,rpm";
+    dtb="--dt $split_img/$dtb";
   fi;
   cd /tmp/anykernel;
   if [ -f "$bin/mkmtkhdr" ]; then


### PR DESCRIPTION
elftool fails to repack the ELF boot image on Sony devices when a custom dtb file is not provided within the AnyKernel2 zip, because the "dtb" variable, that contains the name of the dtb file, is overridden before the dtb filename is actually passed to the "rpm" variable. Initializing the "rpm" variable before re-assigning the "dtb" variable fixes the issue (tested by me on a Sony Xperia SP).