### PR TITLE
restore_file and more universal boot img detection

### DIFF
--- a/META-INF/com/google/android/update-binary
+++ b/META-INF/com/google/android/update-binary
@@ -89,6 +89,7 @@ if [ "$(file_getprop /tmp/anykernel/anykernel.sh do.devicecheck)" == 1 ]; then
     if [ "$(getprop ro.product.device)" == "$testname" -o "$(getprop ro.build.product)" == "$testname" ]; then
       ui_print "$testname";
       match=1;
+      break;            
     fi;
   done;
   ui_print " ";

--- a/anykernel.sh
+++ b/anykernel.sh
@@ -17,9 +17,19 @@ device.name5=
 } # end properties
 
 # shell variables
-block=/dev/block/platform/omap/omap_hsmmc.0/by-name/boot;
 is_slot_device=0;
 ramdisk_compression=auto;
+# determine the location of the boot partition
+if [ "$(find /dev/block -name boot | head -n 1)" ]; then
+  block=$(find /dev/block -name boot | head -n 1)
+elif [ -e /dev/block/platform/sdhci-tegra.3/by-name/LNX ]; then
+  block=/dev/block/platform/sdhci-tegra.3/by-name/LNX
+else
+  abort "! Boot img not found! Aborting!"
+fi
+
+# force expansion of the path so we can use it
+block=`echo -n $block`;                                                 
 
 
 ## AnyKernel methods (DO NOT CHANGE)

--- a/tools/ak2-core.sh
+++ b/tools/ak2-core.sh
@@ -107,6 +107,7 @@ unpack_ramdisk() {
     ui_print " "; ui_print "Unpacking ramdisk failed. Aborting..."; exit 1;
   fi;
   test ! -z "$(ls /tmp/anykernel/rdtmp)" && cp -af /tmp/anykernel/rdtmp/* $ramdisk;
+  rm -f $ramdisk/placeholder;                           
 }
 dump_boot() {
   split_boot;
@@ -338,6 +339,9 @@ write_boot() {
 # backup_file <file>
 backup_file() { test ! -f $1~ && cp $1 $1~; }
 
+# restore_file <file>
+restore_file() { test -f $1~ && mv -f $1~ $1; }
+
 # replace_string <file> <if search string> <original string> <replacement string>
 replace_string() {
   if [ -z "$(grep "$2" $1)" ]; then
@@ -482,6 +486,9 @@ patch_prop() {
     sed -i "${line}s;.*;${2}=${3};" $1;
   fi;
 }
+
+# grep_prop <prop name>
+grep_prop() { grep "^$1" "/system/build.prop" | cut -d= -f2; }
 
 # slot detection enabled by is_slot_device=1 (from anykernel.sh)
 if [ "$is_slot_device" == 1 ]; then


### PR DESCRIPTION
- break out of devicecheck look if match is found
- have more universal boot img detection
- remove placeholder if still present in ramdisk folder
- add restore_file function
- add grep_prop function to ak2-core