### PR TITLE
Slot autodetect

### DIFF
--- a/anykernel.sh
+++ b/anykernel.sh
@@ -18,7 +18,6 @@ device.name5=
 
 # shell variables
 block=/dev/block/platform/omap/omap_hsmmc.0/by-name/boot;
-is_slot_device=0;
 ramdisk_compression=auto;
 
 
@@ -39,21 +38,21 @@ dump_boot;
 # begin ramdisk changes
 
 # init.rc
-backup_file init.rc;
-replace_string init.rc "cpuctl cpu,timer_slack" "mount cgroup none /dev/cpuctl cpu" "mount cgroup none /dev/cpuctl cpu,timer_slack";
-append_file init.rc "run-parts" init;
+backup_file $overlay/init.rc;
+replace_string $overlay/init.rc "cpuctl cpu,timer_slack" "mount cgroup none /dev/cpuctl cpu" "mount cgroup none /dev/cpuctl cpu,timer_slack";
+append_file $overlay/init.rc "run-parts" init;
 
 # init.tuna.rc
-backup_file init.tuna.rc;
-insert_line init.tuna.rc "nodiratime barrier=0" after "mount_all /fstab.tuna" "\tmount ext4 /dev/block/platform/omap/omap_hsmmc.0/by-name/userdata /data remount nosuid nodev noatime nodiratime barrier=0";
-append_file init.tuna.rc "dvbootscript" init.tuna;
+backup_file $overlay/init.tuna.rc;
+insert_line $overlay/init.tuna.rc "nodiratime barrier=0" after "mount_all /fstab.tuna" "\tmount ext4 /dev/block/platform/omap/omap_hsmmc.0/by-name/userdata /data remount nosuid nodev noatime nodiratime barrier=0";
+append_file $overlay/init.tuna.rc "dvbootscript" init.tuna;
 
 # fstab.tuna
-backup_file fstab.tuna;
-patch_fstab fstab.tuna /system ext4 options "noatime,barrier=1" "noatime,nodiratime,barrier=0";
-patch_fstab fstab.tuna /cache ext4 options "barrier=1" "barrier=0,nomblk_io_submit";
-patch_fstab fstab.tuna /data ext4 options "data=ordered" "nomblk_io_submit,data=writeback";
-append_file fstab.tuna "usbdisk" fstab;
+backup_file $overlay/fstab.tuna;
+patch_fstab $overlay/fstab.tuna /system ext4 options "noatime,barrier=1" "noatime,nodiratime,barrier=0";
+patch_fstab $overlay/fstab.tuna /cache ext4 options "barrier=1" "barrier=0,nomblk_io_submit";
+patch_fstab $overlay/fstab.tuna /data ext4 options "data=ordered" "nomblk_io_submit,data=writeback";
+append_file $overlay/fstab.tuna "usbdisk" fstab;
 
 # end ramdisk changes
 

--- a/tools/ak2-core.sh
+++ b/tools/ak2-core.sh
@@ -137,7 +137,7 @@ unpack_ramdisk() {
   test ! -z "$(ls /tmp/anykernel/rdtmp)" && cp -af /tmp/anykernel/rdtmp/* $ramdisk;
 }
 dump_boot() {
-  detect_slot;            
+  slot_detect;            
   split_boot;
   unpack_ramdisk;
 }


### PR DESCRIPTION
Add autodetection for slot devices. Allows one ak2 zip to be used for pixels and non-pixels for example. Only caveat is that all ramdisk files need to have $overlay/ in front of them.
However, if the mod isn't going to be used on any slot devices, the $overlay/ doesn't need to be used