### PR TITLE
Add boot img detection and slot function

### DIFF
--- a/tools/ak2-core.sh
+++ b/tools/ak2-core.sh
@@ -30,6 +30,93 @@ reset_ak() {
   . /tmp/anykernel/tools/ak2-core.sh $FD;
 }
 
+# slot detection enabled by is_slot_device=1 (from anykernel.sh)
+if [ "$is_slot_device" == 1 -o "$is_slot_device" == "auto" ]; then
+  slot=$(getprop ro.boot.slot_suffix 2>/dev/null);
+  test ! "$slot" && slot=$(grep -o 'androidboot.slot_suffix=.*$' /proc/cmdline | cut -d\  -f1 | cut -d= -f2);
+  if [ ! "$slot" ]; then
+    slot=$(getprop ro.boot.slot 2>/dev/null);
+    test ! "$slot" && slot=$(grep -o 'androidboot.slot=.*$' /proc/cmdline | cut -d\  -f1 | cut -d= -f2);
+    test "$slot" && slot=_$slot;
+  fi;
+  if [ "$slot" ]; then
+    bootimage=`find /dev/block -iname boot$slot | head -n 1` 2>/dev/null;
+  fi;
+  if [ $? != 0 -a "$is_slot_device" == 1 ]; then
+    ui_print " "; ui_print "Unable to determine active boot slot. Aborting..."; exit 1;
+  fi;
+fi;
+
+# find the location of the boot block
+find_boot() {
+  # if we already have boot block set then verify and use it
+  if [ "$block" != "auto" ] && [ -e "`readlink -f $block`" ]; then
+    block=`readlink -f $block`;
+    [ "$slot" ] && test -e "$block$slot" && block=$block$slot;
+    return;
+  elif [ ! -z $bootimage ]; then
+    block=$bootimage;
+    return;
+  else
+    block=;
+  fi
+  # auto-detect
+  if [ -z $block ]; then
+    for blocks in ramdisk boot_a kern-a android_boot kernel boot lnx bootimg; do
+      block=`find /dev/block -iname $blocks | head -n 1` 2>/dev/null;
+      [ ! -z $block ] && return;
+    done
+  fi
+  # Recovery fallback
+  if [ -z $block ]; then
+    for fstabs in /fstab.* /system/vendor/etc/fstab.* /etc/*fstab*; do
+      block=`grep -v '#' $fstabs | grep -E '/boot[^a-zA-Z]' | grep -oE '/dev/[a-zA-Z0-9_./-]*'`;
+      [ ! -z $block ] && return;
+    done
+  fi
+  [ ! -z $block ] && block=`readlink -f $block`;
+  # Weird partition layouts
+  if [ -f /proc/emmc ]; then
+    # emmc layout
+    block=$(awk '$4 == "\"boot\"" {print $1}' /proc/emmc);
+    [ "$block" ] && block=/dev/block/$(echo "$block" | cut -f1 -d:) && return;
+  fi
+  if [ -f /proc/mtd ]; then
+    # mtd layout
+    block=$(awk '$4 == "\"boot\"" {print $1}' /proc/mtd);
+    [ "$block" ] && block=/dev/block/$(echo "$block" | cut -f1 -d:) && if [ -f $bin/flash_erase -a -f $bin/nanddump -a -f $bin/nandwrite ]; then return; else ui_print "MTD device detected!"; ui_print "Required binaries missing!"; exit 1; fi;
+  fi
+  if [ -f /proc/dumchar_info ]; then
+    # mtk layout
+    block=$(awk '$1 == "/boot" {print $5}' /proc/dumchar_info);
+    [ "$block" ] && if [ ! -f $bin/mkmtkhdr ]; then return; else ui_print "MTK device detected!"; ui_print "Required binaries missing!"; exit 1; fi;
+  fi
+  ui_print "Unable to find boot block location!";
+  exit 1;
+}
+# Slot device support
+slot_device() {
+  if [ ! -z $slot ]; then           
+    if [ -d $ramdisk/.subackup -o -d $ramdisk/.backup ]; then
+      patch_cmdline "skip_override" "skip_override";
+    else
+      patch_cmdline "skip_override" "";
+    fi
+    # Overlay stuff
+    if [ -d $ramdisk/.backup ]; then
+      overlay=$ramdisk/overlay;
+    elif [ -d $ramdisk/.subackup ]; then
+      overlay=$ramdisk/boot;
+    fi
+    for rdfile in $list; do
+      rddir=$(dirname $rdfile);
+      mkdir -p $overlay/$rddir;
+      test ! -f $overlay/$rdfile && cp -rp /system/$rdfile $overlay/$rddir/;
+    done                       
+  else
+    overlay=$ramdisk;
+  fi
+}
 # dump boot and extract ramdisk
 split_boot() {
   if [ ! -e "$(echo $block | cut -d\  -f1)" ]; then
@@ -121,6 +208,8 @@ unpack_ramdisk() {
   test ! -z "$(ls /tmp/anykernel/rdtmp)" && cp -af /tmp/anykernel/rdtmp/* $ramdisk;
 }
 dump_boot() {
+  find_boot;
+  slot_device;
   split_boot;
   unpack_ramdisk;
 }
@@ -518,23 +607,6 @@ if [ ! -d "$ramdisk" -a ! -d "$patch" ]; then
   touch /tmp/anykernel/$(basename $block)-files/current;
 fi;
 test ! -d "$ramdisk" && mkdir -p $ramdisk;
-
-# slot detection enabled by is_slot_device=1 (from anykernel.sh)
-if [ "$is_slot_device" == 1 -o "$is_slot_device" == "auto" ]; then
-  slot=$(getprop ro.boot.slot_suffix 2>/dev/null);
-  test ! "$slot" && slot=$(grep -o 'androidboot.slot_suffix=.*$' /proc/cmdline | cut -d\  -f1 | cut -d= -f2);
-  if [ ! "$slot" ]; then
-    slot=$(getprop ro.boot.slot 2>/dev/null);
-    test ! "$slot" && slot=$(grep -o 'androidboot.slot=.*$' /proc/cmdline | cut -d\  -f1 | cut -d= -f2);
-    test "$slot" && slot=_$slot;
-  fi;
-  if [ "$slot" ]; then
-    test -e "$block$slot" && block=$block$slot;
-  fi;
-  if [ $? != 0 -a "$is_slot_device" == 1 ]; then
-    ui_print " "; ui_print "Unable to determine active boot slot. Aborting..."; exit 1;
-  fi;
-fi;
 
 ## end methods
 


### PR DESCRIPTION
This is by no means a finished product but at least somewhere to start

Attempt number 2:

I compared supersu and magisk methods and they're basically the same except magisk seems to be a bit more concise and supports more fstab files so I initially used magisk method. I then modified it's recovery fallback to use all fstab files (including vendor/etc/ones in oreo roms).
Then I used the lazyflasher logic for the last few oddball boot schemes.

I also added the slot_device function since you now have auto option for slot detection and moved the slot detection to before the find_boot function since slot is needed for that

Let me know what you think :)