### PR TITLE
AK2: Allow reading multiple lines from version file

### DIFF
--- a/META-INF/com/google/android/update-binary
+++ b/META-INF/com/google/android/update-binary
@@ -74,7 +74,9 @@ fi;
 ui_print "$(file_getprop /tmp/anykernel/anykernel.sh kernel.string)";
 if [ -f /tmp/anykernel/version ]; then
   ui_print " ";
-  ui_print "$(cat /tmp/anykernel/version)";
+  while IFS='' read -r line || $bb [[ -n "$line" ]]; do
+    ui_print "$line";
+  done < /tmp/anykernel/version;
   ui_print " ";
 fi;
 ui_print " ";


### PR DESCRIPTION
This becomes handy to display some additional details apart from just showing the kernel version