### PR TITLE
AK2: Expose dtbo flashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ repack_ramdisk
 flash_boot
 write_boot
 reset_ak
+flash_dtbo
 ```
 
 __"if search string"__ is the string it looks for to decide whether it needs to add the tweak or not, so generally something to indicate the tweak already exists. __"cmdline entry name"__ behaves somewhat like this as a match check for the name of the cmdline entry to be changed/added by the _patch_cmdline_ function, followed by the full entry to replace it. __"prop name"__ also serves as a match check in _patch_prop_ for a property in the given prop file, but is only the prop name as the prop value is specified separately.
@@ -74,7 +75,7 @@ __"before|after"__ requires you simply specify __"before"__ or __"after"__ for t
 
 __"block|mount|fstype|options|flags"__ requires you specify which part (listed in order) of the fstab entry you want to check and alter.
 
-_dump_boot_ and _write_boot_ are the default method of unpacking/repacking, but for more granular control, or omitting ramdisk changes entirely ("OG AK" mode), these can be separated into _split_boot; unpack_ramdisk_ and _repack_ramdisk; flash_boot_ respectively.
+_dump_boot_ and _write_boot_ are the default method of unpacking/repacking, but for more granular control, or omitting ramdisk changes entirely ("OG AK" mode), these can be separated into _split_boot; unpack_ramdisk_ and _repack_ramdisk; flash_boot_ respectively. _flash_dtbo_ can be used to flash a dtbo image. It is automatically included in _write_boot_ but can be called separately if using "OG AK" mode or creating a dtbo only zip.
 
 Multi-partition zips can be created by removing the ramdisk and patch folders from the zip and including instead "-files" folders named for the partition (without slot suffix), e.g. boot-files + recovery-files, or kernel-files + ramdisk-files (on some Treble devices). These then contain zImage, and ramdisk, patch, etc. subfolders for each partition. To setup for the next partition, simply set `block=` and `ramdisk_compression=` for the new target partition and use the _reset_ak_ command.
 

--- a/tools/ak2-core.sh
+++ b/tools/ak2-core.sh
@@ -335,11 +335,11 @@ flash_boot() {
     dd if=/dev/zero of=$block 2>/dev/null;
     dd if=/tmp/anykernel/boot-new.img of=$block;
   fi;
-  flash_dtbo;
 }
 write_boot() {
   repack_ramdisk;
   flash_boot;
+  flash_dtbo;
 }
 
 # backup_file <file>


### PR DESCRIPTION
Some zips may want to flash just the dtbo so add a function that can be
called in anykernel.sh to make that happen.