### PR TITLE
auto detect mount point

### DIFF
--- a/anykernel.sh
+++ b/anykernel.sh
@@ -19,7 +19,7 @@ supported.patchlevels=
 '; } # end properties
 
 # shell variables
-block=/dev/block/platform/omap/omap_hsmmc.0/by-name/boot;
+block=$(find /dev/block | grep -i "by-name/boot")
 is_slot_device=0;
 ramdisk_compression=auto;
 


### PR DESCRIPTION
normally people could define mount point when they make the zip, but for me there are 2 twrp's with slightly different mount points . so i had to make 2 zips , as a fix i did this.
this will look for the mount point while installing and will detect it
directly copied from **SuperR's kitchen** `tools/updater/install/bin/configure.sh`
there are more ways in the script but as i found this line is enough for my device
as a person with more knowledge than me you may be able to do something else or improve what i did to achieve the result 
and a _big thanks and hugs for the project_