### PR TITLE
AK3: Add -n flag when unpacking with magiskboot

### DIFF
--- a/tools/ak3-core.sh
+++ b/tools/ak3-core.sh
@@ -126,7 +126,7 @@ split_boot() {
   elif [ -f "$bin/rkcrc" ]; then
     dd bs=4096 skip=8 iflag=skip_bytes conv=notrunc if=$bootimg of=ramdisk.cpio.gz;
   else
-    $bin/magiskboot unpack -h $bootimg;
+    $bin/magiskboot unpack -n -h $bootimg;
     case $? in
       1) dumpfail=1;;
       2) touch chromeos;;


### PR DESCRIPTION
In the latest version of magiskboot, if we don't add the -n parameter when unpacking,
magiskboot will decompress the kernel and ramdisk.cpio immediately.

This will result in:
1. If we do not provide any kernel image to be replaced, then magiskboot will include
the uncompressed $split_img/kernel when repacking boot.img
2. ... However, if we keep the ramdisk_compression variable as "auto" or "", the
ramdisk and kernel will still be compressed during repackaging (compress with the
same method in original boot.img). Because we didn't add the -n parameter when
repackaging, this caused magiskboot to automatically compress them.

This has caused too much confusion, so we should prevent magiskboot from
automatically decompressing the kernel and ramdisk when unpacking.