### PR TITLE
AK3: Fix patch_fstab function

### DIFF
--- a/tools/ak3-core.sh
+++ b/tools/ak3-core.sh
@@ -615,7 +615,7 @@ replace_file() {
 # patch_fstab <fstab file> <mount match name> <fs match type> block|mount|fstype|options|flags <original string> <replacement string>
 patch_fstab() {
   local entry part newpart newentry;
-  entry=$(grep "$2" $1 | grep "$3");
+  entry=$(grep "$2[[:space:]]" $1 | grep "$3");
   if [ ! "$(echo "$entry" | grep "$6")" -o "$6" == " " -o ! "$6" ]; then
     case $4 in
       block) part=$(echo "$entry" | awk '{ print $1 }');;


### PR DESCRIPTION
Patching system partition entry won't work if system_ext partition is present. Fix this by adding [[:space:]] to the end of the pattern.
Note that grep -w can't be used in this case because there is still a possibility of erroneous matches, e.g., logical vendor partition (that is just "vendor") and "/vendor/dsp".

Reported-by: Wiley Lau <henloboii@protonmail.ch>