### PR TITLE
Backend: introduce Android SDK level check

### DIFF
--- a/META-INF/com/google/android/update-binary
+++ b/META-INF/com/google/android/update-binary
@@ -321,6 +321,33 @@ do_versioncheck() {
     abort " " "Unsupported Android version. Aborting...";
   fi;
 }
+do_sdkcheck() {
+  [ "$(file_getprop anykernel.sh supported.sdk)" ] || return 1;
+  local android_sdk hi_sdk lo_sdk parsed_sdk supported supported_sdk;
+  ui_print "Checking SDK version...";
+  supported_sdk=$(file_getprop anykernel.sh supported.sdk | $BB tr -d '[:space:]');
+  android_sdk=$(file_getprop /system/build.prop ro.build.version.sdk);
+  parsed_sdk=$(int2ver $android_sdk);
+  if echo $supported_sdk | $BB grep -q '-'; then
+    lo_sdk=$(int2ver "$(echo $supported_sdk | $BB cut -d- -f1)");
+    hi_sdk=$(int2ver "$(echo $supported_sdk | $BB cut -d- -f2)");
+    if echo -e "$hi_sdk\n$lo_sdk\n$parsed_sdk" | $BB sort -g | $BB grep -n "$parsed_sdk" | $BB grep -q '^2:'; then
+      supported=1;
+    fi;
+  else
+    for sdk in $(echo $supported_sdk | $BB sed 's;,; ;g'); do
+      if [ "$(int2ver $sdk)" == "$parsed_sdk" ]; then
+        supported=1;
+        break;
+      fi;
+    done;
+  fi;
+  if [ "$supported" ]; then
+    ui_print "$android_sdk" " ";
+  else
+    abort " " "Unsupported sdk version. Aborting...";
+  fi;
+}
 do_levelcheck() {
   [ "$(file_getprop anykernel.sh supported.patchlevels)" ] || return 1;
   local android_lvl hi_lvl lo_lvl parsed_lvl supported_lvl;
@@ -479,6 +506,7 @@ setup_env;
 
 do_devicecheck;
 do_versioncheck;
+do_sdkcheck;
 do_levelcheck;
 
 ui_print "Installing...";

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ __do.cleanuponabort=0__ will keep the zip from removing its working directory in
 
 __supported.versions=__ will match against ro.build.version.release from the current ROM's build.prop. It can be set to a list or range. As a list of one or more entries, e.g. `7.1.2` or `8.1.0, 9` it will look for exact matches, as a range, e.g. `7.1.2 - 9` it will check to make sure the current version falls within those limits. Whitespace optional, and supplied version values should be in the same number format they are in the build.prop value for that Android version.
 
+__supported.sdk=__ will match against ro.build.version.sdk from the current ROM's build.prop. It can be set to a list or range. As a list of one or more entries, e.g. `31` or `31, 32` it will look for exact matches, as a range, e.g. `31 - 32` it will check to make sure the current version falls within those limits. Whitespace optional, and supplied version values should be in the same number format they are in the build.prop value for that sdk version.
+
 __supported.patchlevels=__ will match against ro.build.version.security_patch from the current ROM's build.prop. It can be set as a closed or open-ended range of dates in the format YYYY-MM, whitespace optional, e.g. `2019-04 - 2019-06`, `2019-04 -` or `- 2019-06` where the last two examples show setting a minimum and maximum, respectively.
 
 `block=auto` instead of a direct block filepath enables detection of the device boot partition for use with broad, device non-specific zips. Also accepts specifically `boot`, `recovery` or `vendor_boot`.

--- a/anykernel.sh
+++ b/anykernel.sh
@@ -16,6 +16,7 @@ device.name3=toroplus
 device.name4=tuna
 device.name5=
 supported.versions=
+supported.sdk=
 supported.patchlevels=
 '; } # end properties
 


### PR DESCRIPTION
- checks supported.sdk prop in anykernel.sh and matches against it to prevent flashing on unsupported sdk
- this check is useful if checking for Android version and Android security patch level is not sufficient
- Android 12L Beta and stable Android 12 Firmware on Pixels might both show ro.build.version.release=12 while inheriting the same security patch level (On Pixel 6 devices Android 12L kernel build will bootloop on A12 stable and vice versa)
- logic for this check was taken from existing check for android version