### PR TITLE
AK3: add support for vendor_kernel_boot

### DIFF
--- a/META-INF/com/google/android/updater-script
+++ b/META-INF/com/google/android/updater-script
@@ -3,4 +3,4 @@
 # Dummy file; update-binary is a shell script (DO NOT CHANGE)
 #
 #
-# AK_BASE_VERSION=20220827
+# AK_BASE_VERSION=20221019

--- a/tools/ak3-core.sh
+++ b/tools/ak3-core.sh
@@ -508,12 +508,12 @@ flash_generic() {
 # flash_dtbo (backwards compatibility for flash_generic)
 flash_dtbo() { flash_generic dtbo; }
 
-### write_boot (repack ramdisk then build, sign and write image, vendor_dlkm/vendor_kernel_boot and dtbo)
+### write_boot (repack ramdisk then build, sign and write image, vendor_dlkm and dtbo)
 write_boot() {
   repack_ramdisk;
   flash_boot;
   flash_generic vendor_boot; # temporary until hdr v4 can be unpacked/repacked fully by magiskboot
-  flash_generic vendor_kernel_boot;
+  flash_generic vendor_kernel_boot; # temporary until hdr v4 can be unpacked/repacked fully by magiskboot
   flash_generic vendor_dlkm;
   flash_generic dtbo;
 }

--- a/tools/ak3-core.sh
+++ b/tools/ak3-core.sh
@@ -508,11 +508,12 @@ flash_generic() {
 # flash_dtbo (backwards compatibility for flash_generic)
 flash_dtbo() { flash_generic dtbo; }
 
-### write_boot (repack ramdisk then build, sign and write image, vendor_dlkm and dtbo)
+### write_boot (repack ramdisk then build, sign and write image, vendor_dlkm/vendor_kernel_boot and dtbo)
 write_boot() {
   repack_ramdisk;
   flash_boot;
   flash_generic vendor_boot; # temporary until hdr v4 can be unpacked/repacked fully by magiskboot
+  flash_generic vendor_kernel_boot;
   flash_generic vendor_dlkm;
   flash_generic dtbo;
 }


### PR DESCRIPTION
This image is used on A13 launch devices, currently used on Pixel 7/7 Pro devices