### PR TITLE
AK3+Backend: helper module improvements and full KernelSU support

### DIFF
--- a/META-INF/com/google/android/update-binary
+++ b/META-INF/com/google/android/update-binary
@@ -385,28 +385,63 @@ cat <<'EOF' > $1;
 MODDIR=${0%/*};
 if [ "$(cat /proc/version)" != "$(cat $MODDIR/version)" ]; then
   rm -rf $MODDIR;
+  exit;
 fi;
+rm -f $MODDIR/update;
+. $MODDIR/post-fs-data.2.sh;
 EOF
 }
 do_modules() {
   [ "$(file_getprop anykernel.sh do.modules)" == 1 ] || return 1;
-  local block modcon moddir modtarget module slot umask;
+  local block modcon moddir modtarget module slot umask umountksu;
   if [ "$(file_getprop anykernel.sh do.systemless)" == 1 ]; then
+    if [ ! -d /data/adb -o ! -d /data/data/android ]; then
+      ui_print " " "Warning: No /data access for kernel helper systemless module!";
+      return 1;
+    fi;
     cd $AKHOME/modules;
     ui_print " " "Creating kernel helper systemless module...";
-    if [ -d /data/adb/magisk -a -f $AKHOME/magisk_patched ] || [ -d /data/adb/ksu -a -f $AKHOME/kernelsu_patched ]; then
+    if [ -d /data/adb/magisk -a -f $AKHOME/magisk_patched ] || [ -d /data/data/me.weishu.kernelsu -a -f $AKHOME/kernelsu_patched ]; then
       umask=$(umask);
-      umask 022;
       moddir=/data/adb/modules/ak3-helper;
+      # this may be the initial KernelSU install or first module so setup as needed
+      if [ -f $AKHOME/kernelsu_patched ]; then
+        umask 077;
+        if [ ! -d /data/adb/modules ]; then
+          mkdir -p /data/adb/modules;
+          chmod 777 /data/adb/modules;
+        fi;
+        [ -d /data/adb/modules_update ] || mkdir -p /data/adb/modules_update;
+        [ -d /data/adb/ksu ] || mkdir -p /data/adb/ksu;
+        [ -f /data/adb/ksu/modules.img ] && cp -f /data/adb/ksu/modules.img /data/adb/ksu/modules_update.img;
+        if [ ! -f /data/adb/ksu/modules_update.img ]; then
+          /system/bin/make_ext4fs -b 1024 -l 256M /data/adb/ksu/modules_update.img 2>/dev/null \
+            || /system/bin/mke2fs -b 1024 -t ext4 /data/adb/ksu/modules_update.img 256M;
+        fi;
+        mount -t ext4 -o rw /data/adb/ksu/modules_update.img /data/adb/modules_update && umountksu=1;
+        touch /data/adb/ksu/update;
+        umask 022;
+        rm -rf $moddir;
+        mkdir -p $moddir;
+        dump_moduleinfo $moddir/module.prop;
+        touch $moddir/update;
+        moddir=/data/adb/modules_update/ak3-helper;
+      fi;
+      umask 022;
       rm -rf $moddir;
       mkdir -p system $moddir;
       (mv -f product system;
-      mv -f vendor system) 2>/dev/null;
+      mv -f vendor system;
+      mv -f system_ext system;
+      mv -f post-fs-data.sh post-fs-data.2.sh) 2>/dev/null;
       cp -rLf * $moddir;
       dump_moduleinfo $moddir/module.prop;
       dump_moduleremover $moddir/post-fs-data.sh;
       cp -f $AKHOME/vertmp $moddir/version;
+      touch $moddir/update;
       umask $umask;
+      chcon -hR "u:object_r:system_file:s0" $moddir;
+      [ "$umountksu" ] && umount /data/adb/modules_update;
     else
       ui_print "Magisk/KernelSU installation not found. Skipped!";
     fi;

--- a/META-INF/com/google/android/updater-script
+++ b/META-INF/com/google/android/updater-script
@@ -3,4 +3,4 @@
 # Dummy file; update-binary is a shell script (DO NOT CHANGE)
 #
 #
-# AK_BASE_VERSION=20230704
+# AK_BASE_VERSION=20230716

--- a/tools/ak3-core.sh
+++ b/tools/ak3-core.sh
@@ -329,7 +329,7 @@ flash_boot() {
           fi;
           # legacy SAR kernel string skip_initramfs -> want_initramfs
           $bin/magiskboot hexpatch kernel 736B69705F696E697472616D6673 77616E745F696E697472616D6673;
-          if [ "$(file_getprop $home/anykernel.sh do.systemless)" == 1 ]; then
+          if [ "$(file_getprop $home/anykernel.sh do.modules)" == 1 ] && [ "$(file_getprop $home/anykernel.sh do.systemless)" == 1 ]; then
             strings kernel 2>/dev/null | grep -E -m1 'Linux version.*#' > $home/vertmp;
           fi;
           if [ "$comp" ]; then
@@ -345,7 +345,7 @@ flash_boot() {
           for fdt in dtb extra kernel_dtb recovery_dtbo; do
             [ -f $fdt ] && $bin/magiskboot dtb $fdt patch; # remove dtb verity/avb
           done;
-        elif [ -d /data/adb/ksu -a -f /data/adb/ksu/modules.img ] && [ "$(file_getprop $home/anykernel.sh do.systemless)" == 1 ]; then
+        elif [ -d /data/data/me.weishu.kernelsu ] && [ "$(file_getprop $home/anykernel.sh do.modules)" == 1 ] && [ "$(file_getprop $home/anykernel.sh do.systemless)" == 1 ]; then
           ui_print " " "KernelSU detected! Setting up for kernel helper module...";
           comp=$($bin/magiskboot decompress kernel 2>&1 | grep -vE 'raw|zimage' | sed -n 's;.*\[\(.*\)\];\1;p');
           ($bin/magiskboot split $kernel || $bin/magiskboot decompress $kernel kernel) 2>/dev/null;


### PR DESCRIPTION
- only parse kernel strings when both do.modules=1 and do.systemless=1 are set
- support post-fs-data.sh in systemless kernel helper module (gets renamed and sourced from the built-in one)
- show systemless kernel helper module as an update pending reboot in module apps if flashed while booted
- add system_ext support to systemless kernel helper module
- show a warning during flash if systemless kernel helper module is configured but there's no decrypted /data access to be able to install it
- detect the installed KernelSU app as the indicator the user intends to use KernelSU, and install systemless kernel helper module to modules_update.img accordingly
- do KernelSU directory setup and create modules_update.img if this appears to be the initial KernelSU install
- set all systemless kernel helper module files to system_file context, since unlabeled files are not gracefully handled by KernelSU (they trigger a reboot and the module gets rejected)

NOTE: currently it appears KernelSU won't parse the modules_update.img on the first boot where it sets itself up from initial KernelSU install, but it will then do it after the following reboot. Hopefully this can be fixed by a future KernelSU release so that the systemless kernel helper module is active right away as this might be necessary to boot fully on some devices.

...

PR as a workaround for multi-file commits until my laptop is fixed 😅