### PR TITLE
AK3: add per-partition attributes, multi-partition fixes

### DIFF
--- a/META-INF/com/google/android/updater-script
+++ b/META-INF/com/google/android/updater-script
@@ -3,4 +3,4 @@
 # Dummy file; update-binary is a shell script (DO NOT CHANGE)
 #
 #
-# AK_BASE_VERSION=20230801
+# AK_BASE_VERSION=20230810

--- a/tools/ak3-core.sh
+++ b/tools/ak3-core.sh
@@ -848,17 +848,6 @@ setup_ak() {
     touch vendor_v3_setup;
   fi;
 
-  # allow multi-partition ramdisk modifying configurations (using reset_ak)
-  if [ "$block" ] && [ ! -d "$ramdisk" -a ! -d "$patch" ]; then
-    blockfiles=$home/$(basename $block)-files;
-    if [ "$(ls $blockfiles 2>/dev/null)" ]; then
-      cp -af $blockfiles/* $home;
-    else
-      mkdir $blockfiles;
-    fi;
-    touch $blockfiles/current;
-  fi;
-
   # target block partition detection enabled by block=<partition filename> or auto (from anykernel.sh)
   case $block in
     /dev/*)
@@ -915,6 +904,22 @@ setup_ak() {
   if [ ! "$no_block_display" ]; then
     ui_print "$block";
   fi;
+  
+  # allow multi-partition ramdisk modifying configurations (using reset_ak)
+  name=$(basename $block | sed -e 's/_a$//' -e 's/_b$//');
+  if [ "$block" ] && [ ! -d "$ramdisk" -a ! -d "$patch" ]; then
+    blockfiles=$home/$name-files;
+    if [ "$(ls $blockfiles 2>/dev/null)" ]; then
+      cp -af $blockfiles/* $home;
+    else
+      mkdir $blockfiles;
+    fi;
+    touch $blockfiles/current;
+  fi;
+
+  # run attributes function for current block if it exists
+  type attributes >/dev/null 2>&1 && attributes; # backwards compatibility
+  type ${name}_attributes >/dev/null 2>&1 && ${name}_attributes;
 }
 ###
 


### PR DESCRIPTION
- attributes function now runs via core in setup_ak and reset_ak, but only if it exists, allowing more easy removal of it for setups with no ramdisk changes (so all should now remove the awkward `&& attributes` call from anykernel3.sh, see next commit)
- for multi-partition zips with multiple ramdisks requiring different files, multiple attributes functions may now be specified, either redefine attributes() in anykernel.sh for the next partition, or add a different function for each partition, e.g. boot_attributes() and vendor_boot_attributes()
- fix block=auto multi-partition setup creating an "auto-files" directory instead of final found block, e.g. "init_boot-files"

...

PR as a workaround for multi-file commits until my laptop is fixed 😅